### PR TITLE
Use URLSearchParams to generate querystring

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -40,9 +40,7 @@ export const toInt = (x) => {
 
 export const toFormUrlencoded = (o) => {
   // application/x-www-form-urlencoded
-  return Object.entries(o)
-    .map(p => p.map(encodeURIComponent).join('='))
-    .join('&');
+  return new URLSearchParams(o).toString()
 };
 
 export async function waitUntil(func, { ms = 100, maxCount = 20 } = {}) {


### PR DESCRIPTION
如題
因為不曉得原本的方法會不會遇到一些 edge case，所以我覺得改用瀏覽器內建的 `URLSearchParams` 搞不好會更好一點