### PR TITLE
Fix third party addons that perform iframe injection

### DIFF
--- a/src/pixiv.override.css
+++ b/src/pixiv.override.css
@@ -54,8 +54,6 @@ ul.menu-items > li.current > a {
 }
 
 /* annoyings, ref: lib/pixiv.js */
-
-iframe,
 /* Ad */
 .ad,
 .ads_area,


### PR DESCRIPTION
Changes introduced in commit https://github.com/FlandreDaisuki/Patchouli/commit/cefadf484679fcf233523087ecef0cf8b65c4e05 breaks 3rd party addons by hiding all iframe elements. e.g. [yomichan](https://foosoft.net/projects/yomichan/), and potentially other userscripts.

This PR removes the overzealous CSS rule.